### PR TITLE
Merge Jacocoergebnisse

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
-        run: ./gradlew build sonarqube --info
+        run: ./gradlew build mergeJacocoReports sonarqube --info
       - name: Shutdown Ubuntu MySQL (SUDO)
         run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary, please not remove it

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ sonarqube {
         property "sonar.projectKey", "justinhada_TrainHarder"
         property "sonar.organization", "justinhada"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.coverage.jacoco.xmlReportPaths", mergeJacocoReports.reports.xml.destination
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/merge.xml"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,17 @@ jacoco {
     reportsDir = file("$buildDir/jacoco")
 }
 
-jacocoTestReport {
+task mergeJacocoReports(type: JacocoReport) {
     dependsOn test, integrationTest
-    executionData tasks.withType(Test).findAll {it.state.executed }
+    sourceDirectories.setFrom files(sourceSets.main.allSource.srcDirs)
+    classDirectories.setFrom files(sourceSets.main.output)
+    executionData.setFrom project.fileTree(dir: '.', include: '**/build/jacoco/*.exec')
     reports {
         xml.enabled true
         csv.enabled false
-        html.destination file("${buildDir}/jacoco/jacoco.html")
-        xml.destination file("${buildDir}/jacoco/jacocoAllTestReport.xml")
+        html.enabled true
+        html.destination file("${buildDir}/jacoco/merge")
+        xml.destination file("${buildDir}/jacoco/merge.xml")
     }
 }
 
@@ -65,10 +68,10 @@ sonarqube {
         property "sonar.projectKey", "justinhada_TrainHarder"
         property "sonar.organization", "justinhada"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination
+        property "sonar.coverage.jacoco.xmlReportPaths", mergeJacocoReports.reports.xml.destination
     }
 }
 
-tasks['sonarqube'].dependsOn jacocoTestReport
+tasks['sonarqube'].dependsOn mergeJacocoReports
 
 version = '0.0.2'


### PR DESCRIPTION
Lokale Tests funktionieren in soweit, als dass ein `gradlew clean build mergeJacocoReports` einen Report in `builds/jacoco/merge/index.html` anlegt, welcher auch Pfade aus der Persistanceschicht beinhaltet.